### PR TITLE
Feature/ep 07 background thread stat for CPU and RSS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,16 @@ set(CMAKE_CXX_STANDING 11)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GST REQUIRED gstreamer-1.0)
 
-add_executable(profiler src/main.cpp)
+add_executable(profiler 
+            src/main.cpp
+            src/resource_poller.cpp)
 
 target_include_directories(profiler PRIVATE ${GST_INCLUDE_DIRS} include)
-target_link_libraries(profiler PRIVATE ${GST_LIBRARIES})
+target_link_libraries(profiler PRIVATE 
+                ${GST_LIBRARIES})
+target_link_libraries(profiler PRIVATE
+    ${GST_LIBRARIES}
+    pthread) 
 target_compile_options(profiler PRIVATE
     ${GST_CFLAGS_OTHER}
     -Wall -Wextra)

--- a/include/resource_poller.h
+++ b/include/resource_poller.h
@@ -1,0 +1,74 @@
+#ifndef RESOURCE_POLLER_H
+#define RESOURCE_POLLER_H
+
+#include <thread>
+#include <atomic>
+#include <mutex>
+#include <vector>
+#include <cstdint>
+
+#include "timer.h"
+
+/* ======================================
+    Snapshot stored every 100ms
+    =====================================
+*/
+struct ResourseSnapshot
+{
+    uint64_t timestamp_ns;  // when this was taken
+    double cpu_precent;     // CPU% over last 100ms interval
+    long rss_kb;            // physical RAM in kilobytes
+};
+
+/* ========================================
+    Internal CPU stat from /proc/self/stat
+    =======================================
+*/
+struct CpuStat
+{
+    unsigned long utime;    // user ticks (field 14)
+    unsigned long stime;    // kernel ticks (feild 15)
+
+    CpuStat(): utime(0), stime(0) {}
+};
+
+/* ========================================
+    ResourcePoller class
+    =======================================
+*/
+class ResourcePoller
+{
+    public:
+        ResourcePoller();
+        ~ResourcePoller();
+
+        void start();           // launch background thread
+        void stop();            // signal + join
+
+        // call after stop() - copies shnapshot out safely
+        std::vector<ResourseSnapshot> get_snapshots() const;
+
+    private:
+        // function the background thread runs
+        void poll_loop();
+
+        // /proc readers
+        static CpuStat read_cpu_stat();
+        static long read_rss_kb();
+
+        // thread + stop signal
+        std::thread thread_;
+        std::atomic<bool> running_;
+
+        // snapshot storage - protected by mutex_
+        std::vector<ResourseSnapshot> snapshots_;
+        mutable std::mutex mutex_;
+
+        // disable copy
+        ResourcePoller(const ResourcePoller&) = delete;
+        ResourcePoller& operator=(const ResourcePoller&) = delete;
+
+};
+
+
+#endif

--- a/include/resource_poller.h
+++ b/include/resource_poller.h
@@ -16,7 +16,7 @@
 struct ResourseSnapshot
 {
     uint64_t timestamp_ns;  // when this was taken
-    double cpu_precent;     // CPU% over last 100ms interval
+    double cpu_percent;     // CPU% over last 100ms interval
     long rss_kb;            // physical RAM in kilobytes
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,9 @@
 #include <memory>
 #include <iostream>
 #include <stdlib.h>
+
 #include "../include/timer.h"
+#include "../include/resource_poller.h"
 
 /*
 ===========================================
@@ -228,7 +230,7 @@ int main(int argc, char* argv[])
 
 
         // encoder: ultrafast for now so test quikly
-        g_object_set(encoder, "speed-preset", 1, nullptr);  // 1 = ultrafast
+        g_object_set(encoder, "speed-preset", 6, nullptr);  // 1 = ultrafast
         g_object_set(encoder, "tune", 4, nullptr);          // 4 = zerolatency
 
         // sink: sync false for clock - run as fast as possible
@@ -276,6 +278,9 @@ int main(int argc, char* argv[])
         gst_object_unref(encoder_srcpad);
         gst_object_unref(encoder_sinkpad);
 
+        // Resouces Poller
+        ResourcePoller poller;
+        poller.start();
 
         /* 8. start pipeline */
         GstStateChangeReturn ret = gst_element_set_state(pipeline.get(), GST_STATE_PLAYING);
@@ -291,6 +296,27 @@ int main(int argc, char* argv[])
         g_main_loop_run(loop.get());
 
         std::cout << "[main] done\n";
+
+        // stop poller
+        poller.stop();
+
+        // print summary
+        std::vector<ResourseSnapshot> snaps = poller.get_snapshots();
+        double total_cpu = 0.0;
+        long peak_rss = 0;
+
+        for(size_t i=0; i <snaps.size(); ++i)
+        {
+            total_cpu += snaps[i].cpu_percent;
+            if(snaps[i].rss_kb > peak_rss)
+                peak_rss = snaps[i].rss_kb;
+        }
+
+        double avg_cpu = snaps.empty() ? 0.0 : total_cpu / snaps.size();
+
+        std::cout << "[poller] snapshots   : " << snaps.size() << "\n";
+        std::cout << "[poller] avg CPU%    : " << avg_cpu << "%\n";
+        std::cout << "[poller] peak RSS    : " << peak_rss / 1024 << " MB\n";
 
         /* 10. Exit */
         gst_element_set_state(pipeline.get(), GST_STATE_NULL);

--- a/src/resource_poller.cpp
+++ b/src/resource_poller.cpp
@@ -1,0 +1,141 @@
+#include "../include/resource_poller.h"
+
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <chrono>
+#include <string>
+
+/* ======================================
+    Constructor and Desctructor
+    =====================================
+*/
+
+ResourcePoller::ResourcePoller() : running_(false)
+{}
+
+ResourcePoller::~ResourcePoller() 
+{
+    if(running_.load())
+        stop();
+}
+
+/* ======================================
+    Public APIs
+    =====================================
+*/
+
+void ResourcePoller::start()
+{
+    running_.store(true);
+    // launch poll_loop() on a new thread
+    thread_ = std::thread(&ResourcePoller::poll_loop, this);
+}
+
+void ResourcePoller::stop()
+{
+    running_.store(false);
+    if(thread_.joinable())
+        thread_.join();
+}
+
+std::vector<ResourseSnapshot> ResourcePoller::get_snapshots() const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    return snapshots_;  // return a copy
+}
+
+/* ======================================
+    Background Thread
+    =====================================
+*/
+
+void ResourcePoller::poll_loop()
+{
+    // take first CPU snapshot before the loop
+    CpuStat prev_cpu = read_cpu_stat();
+    uint64_t prev_t = get_time_ns();
+
+    while(running_.load())
+    {
+        // sleep 100ms 
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        // take new CPU snapshot
+        CpuStat curr_cpu = read_cpu_stat();
+        uint64_t curr_t = get_time_ns();
+
+        // compute CPU%
+        unsigned long ticks = (curr_cpu.utime + curr_cpu.stime) - 
+                              (prev_cpu.utime + prev_cpu.stime);
+
+        double cpu_time_ns = ticks * 10000000.0; // 1 tick = 10ms
+        double wall_ns = static_cast<double>(curr_t - prev_t);
+        double cpu_pct = (wall_ns > 0.0) ? (cpu_time_ns / wall_ns) * 100.0 : 0.0;
+
+        // read RAM
+        long rss = read_rss_kb();
+
+        // store snapshot
+        ResourseSnapshot snap;
+        snap.timestamp_ns = curr_t;
+        snap.cpu_precent = cpu_pct;
+        snap.rss_kb = rss;
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            snapshots_.push_back(snap);
+        }
+
+        prev_cpu = curr_cpu;
+        prev_t = curr_t;
+    }
+}
+
+/* ======================================
+    /proc readers
+    =====================================
+*/
+
+CpuStat ResourcePoller::read_cpu_stat()
+{
+    CpuStat s;
+    std::ifstream f("/proc/self/stat");
+    if(!f.is_open())
+    {
+        std::cerr << "[poller] could not open /proc/self/stat\n";
+        return s;
+    }
+
+    std::string token;
+    for(int i=1; i <= 15; ++i)
+    {
+        f >> token;
+        if(i == 14)
+            s.utime = std::stoul(token);
+        if(i == 15)
+            s.stime = std::stoul(token);
+    }
+    return s;
+}
+
+long ResourcePoller::read_rss_kb()
+{
+    std::ifstream f("/proc/self/status");
+    if (!f.is_open()) {
+        std::cerr << "[poller] could not open /proc/self/status\n";
+        return 0;
+    }
+
+    std::string line;
+    while (std::getline(f, line)) {
+        if (line.find("VmRSS:") == 0) {
+            std::istringstream ss(line);
+            std::string label;
+            long kb = 0;
+            ss >> label >> kb;   // "VmRSS:" then the number
+            return kb;
+        }
+    }
+    return 0;
+}

--- a/src/resource_poller.cpp
+++ b/src/resource_poller.cpp
@@ -79,7 +79,7 @@ void ResourcePoller::poll_loop()
         // store snapshot
         ResourseSnapshot snap;
         snap.timestamp_ns = curr_t;
-        snap.cpu_precent = cpu_pct;
+        snap.cpu_percent = cpu_pct;
         snap.rss_kb = rss;
 
         {


### PR DESCRIPTION
Made ResourcePoller class that runs a std::thread in the background which reads CPU and VmRSS (physical RAM).

## Changes
- include/resource_poller.h - Class and functions declrations
- src/resource_poller - CPU usage and RSS read related functions
- CMakeList.txt - modified for class module
- src/main.cpp - used resource_poller resources and functions.

## Tested
\`\`\`
[main] pipeline PLAYING — encoding 300 frames
[probe] frame=1 latency=1.85965e+07ms [KEYFRAME]
[probe] frame=2 latency=5.17479ms [KEYFRAME]
[bus] EOS — all frames encoded
[main] done
[poller] snapshots   : 47
[poller] avg CPU%    : 452.273%
[poller] peak RSS    : 315 MB
\`\`\`

## Acceptance criteria

- [x] start() launches background std::thread
- [x] stop() signals and joins cleanly
- [x] CPU% computed from utime+stime delta / elapsed wall time
- [x] VmRSS read from /proc/self/status in kilobytes
- [x] ResourceSnapshot stored with timestamp, cpu_percent, rss_kb
- [x] CPU% > 90% during active encode (318-452% = 3-4 cores)

## Conclusion
Snap for below Preset 
| Preset | Snapshots | Avg CPU% | Cores used | Peak RSS |
| ultrafast (1) | 28 | 318% | ~3.2 cores | 128 MB |
| medium (6) | 47 | 452% | ~4.5 cores | 315 MB |